### PR TITLE
Adds diacritical marks to pinyin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,14 @@ Usage
 .. code:: python
 
     >>> import pinyin
-    >>> pinyin.get('你好')
-    'nihao'
-    >>> pinyin.get_initial('你好')
-    'n h'
+    >>> print pinyin.get('你 好')
+    nǐ hǎo
+
+    >>> print pinyin.get('你好', format="strip", delimiter=" ")
+    ni hao
+
+    >>> print pinyin.get('你好', format="numerical")
+    ni3hao3
+
+    >>> print pinyin.get_initial('你好')
+    n h

--- a/authors.txt
+++ b/authors.txt
@@ -1,0 +1,2 @@
+Lx Yu
+Piotr Mitros

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='pinyin',
-    version='0.2.5',
+    version='0.3',
     description='Translate chinese chars to pinyin based on Mandarin.dat',
     author='Lx Yu',
     author_email='github@lxyu.net',

--- a/test_pinyin.py
+++ b/test_pinyin.py
@@ -10,33 +10,36 @@ class BasicTestSuite(unittest.TestCase):
     """Basic test cases."""
 
     def test_get(self):
-        self.assertEqual(pinyin.get('你好'), 'nihao')
-        self.assertEqual(pinyin.get(u('你好')), 'nihao')
-        self.assertEqual(pinyin.get('你好吗?'), 'nihaoma?')
-        self.assertEqual(pinyin.get('你好吗？'), u('nihaoma？'))
+        self.assertEqual(pinyin.get('你好'),
+                         pinyin.get('你好', format="diacritical"))
+        self.assertEqual(pinyin.get(u('你好'), format="strip"), u('nihao'))
+        self.assertEqual(pinyin.get(u('你好'), format="numerical"), u('ni3hao3'))
+        self.assertEqual(pinyin.get(u('你好'), format="diacritical"), u('nǐhǎo'))
+        self.assertEqual(pinyin.get('你好吗?'), u('nǐhǎoma?'))
+        self.assertEqual(pinyin.get('你好吗？'), u('nǐhǎoma？'))
 
-        self.assertEqual(pinyin.get('你好'), 'nihao')
-        self.assertEqual(pinyin.get('叶'), 'ye')
+        self.assertEqual(pinyin.get('你好'), u('nǐhǎo'))
+        self.assertEqual(pinyin.get('叶'), u('yè'))
 
     def test_get_with_delimiter(self):
-        self.assertEqual(pinyin.get('你好', " "), 'ni hao')
-        self.assertEqual(pinyin.get('你好吗?', " "), 'ni hao ma ?')
-        self.assertEqual(pinyin.get('你好吗？', " "), u('ni hao ma ？'))
+        self.assertEqual(pinyin.get('你好', " "), u('nǐ hǎo'))
+        self.assertEqual(pinyin.get('你好吗?', " "), u('nǐ hǎo ma ?'))
+        self.assertEqual(pinyin.get('你好吗？', " "), u('nǐ hǎo ma ？'))
 
     def test_get_initial_with_delimiter(self):
-        self.assertEqual(pinyin.get_initial('你好', "-"), 'n-h')
-        self.assertEqual(pinyin.get_initial('你好吗?', "-"), 'n-h-m-?')
+        self.assertEqual(pinyin.get_initial('你好', "-"), u('n-h'))
+        self.assertEqual(pinyin.get_initial('你好吗?', "-"), u('n-h-m-?'))
         self.assertEqual(pinyin.get_initial('你好吗？', "-"), u('n-h-m-？'))
 
     def test_get_initial(self):
-        self.assertEqual(pinyin.get_initial('你好'), 'n h')
-        self.assertEqual(pinyin.get_initial('你好吗?'), 'n h m ?')
+        self.assertEqual(pinyin.get_initial('你好'), u('n h'))
+        self.assertEqual(pinyin.get_initial('你好吗?'), u('n h m ?'))
         self.assertEqual(pinyin.get_initial('你好吗？'), u('n h m ？'))
 
         self.assertEqual(pinyin.get_initial('你好'), 'n h')
 
     def test_mixed_chinese_english_input(self):
-        self.assertEqual(pinyin.get('hi你好'), 'hinihao')
+        self.assertEqual(pinyin.get('hi你好'), u('hinǐhǎo'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This improves the pinyin output of the library by adding diacriticals. Diacriticals are essential especially for Western speakers trying to read pinyin. It maintains the ability to output plain ASCII text by supporting either stripped pinyin or tone numbers.