### PR TITLE
Fix conversion for characters with vowel ü (v)

### DIFF
--- a/pinyin/pinyin.py
+++ b/pinyin/pinyin.py
@@ -37,7 +37,7 @@ def _pinyin_generator(chars, format):
         elif format == "diacritical":
             # Find first vowel -- where we should put the diacritical mark
             vowels = itertools.chain((c for c in pinyin if c in "aeo"),
-                                     (c for c in pinyin if c in "iu"))
+                                     (c for c in pinyin if c in "iuv"))
             vowel = pinyin.index(next(vowels)) + 1
             pinyin = pinyin[:vowel] + tonemarks[tone] + pinyin[vowel:]
         else:

--- a/test_pinyin.py
+++ b/test_pinyin.py
@@ -20,6 +20,7 @@ class BasicTestSuite(unittest.TestCase):
 
         self.assertEqual(pinyin.get('你好'), u('nǐhǎo'))
         self.assertEqual(pinyin.get('叶'), u('yè'))
+        self.assertEqual(pinyin.get('少女'), u('shǎonv̌'))
 
     def test_get_with_delimiter(self):
         self.assertEqual(pinyin.get('你好', " "), u('nǐ hǎo'))
@@ -46,6 +47,7 @@ class BasicTestSuite(unittest.TestCase):
         self.assertEqual(pinyin.get("小"), u("xiǎo"))
         self.assertEqual(pinyin.get("绝"), u("jué"))
         self.assertEqual(pinyin.get("被"), u("bèi"))
+        self.assertEqual(pinyin.get("略"), u("lvè"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Diacritical conversion failed silently for inputs like 少女, returning "shǎo" instead of the correct "shǎonv̌". The code for choosing the right character to add the diacritical mark to failed to consider the "v" (or more correctly, ü) vowel.