### PR TITLE
When using diacritics, replace 'v' with 'ü'

### DIFF
--- a/pinyin/pinyin.py
+++ b/pinyin/pinyin.py
@@ -39,6 +39,7 @@ def _pinyin_generator(chars, format):
             vowels = itertools.chain((c for c in pinyin if c in "aeo"),
                                      (c for c in pinyin if c in "iuv"))
             vowel = pinyin.index(next(vowels)) + 1
+            pinyin = pinyin.replace('v', u('ü'))
             pinyin = pinyin[:vowel] + tonemarks[tone] + pinyin[vowel:]
         else:
             error = "Format must be one of: numerical/diacritical/strip"

--- a/test_pinyin.py
+++ b/test_pinyin.py
@@ -20,7 +20,7 @@ class BasicTestSuite(unittest.TestCase):
 
         self.assertEqual(pinyin.get('你好'), u('nǐhǎo'))
         self.assertEqual(pinyin.get('叶'), u('yè'))
-        self.assertEqual(pinyin.get('少女'), u('shǎonv̌'))
+        self.assertEqual(pinyin.get('少女'), u('shǎonǚ'))
 
     def test_get_with_delimiter(self):
         self.assertEqual(pinyin.get('你好', " "), u('nǐ hǎo'))
@@ -47,7 +47,7 @@ class BasicTestSuite(unittest.TestCase):
         self.assertEqual(pinyin.get("小"), u("xiǎo"))
         self.assertEqual(pinyin.get("绝"), u("jué"))
         self.assertEqual(pinyin.get("被"), u("bèi"))
-        self.assertEqual(pinyin.get("略"), u("lvè"))
+        self.assertEqual(pinyin.get("略"), u("lüè"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This helps with words like 女, for which we previously output 'nv̌'. Now
we return the more conventional 'nǚ'.

Fixes #12 