### PR TITLE
Add pinyin support

### DIFF
--- a/pinyin/pinyin.py
+++ b/pinyin/pinyin.py
@@ -6,7 +6,7 @@ import unicodedata
 
 from ._compat import u
 
-__all__ = ['get', 'get_pinyin', 'get_initial']
+__all__ = ['get', 'get_pinyin', 'get_initial', 'numerical_to_diacritical']
 
 
 # init pinyin dict
@@ -66,5 +66,25 @@ def get_initial(s, delimiter=' '):
     """
     initials = (p[0] for p in _pinyin_generator(u(s), format="strip"))
     return delimiter.join(initials)
+
+
+def numerical_to_diacritical(pinyin):
+    """
+    Example:
+     hai2 shi -> hái shi
+    """
+    phonemes = pinyin.split()
+    result = []
+    for p in phonemes:
+        pinyin, tone = p[:-1], int(p[-1])
+
+        # Find first vowel -- where we should put the diacritical mark
+        vowels = itertools.chain((c for c in pinyin if c in "aeo"),
+                                 (c for c in pinyin if c in "iuv"))
+        vowel = pinyin.index(next(vowels)) + 1
+        pinyin = pinyin[:vowel] + tonemarks[tone] + pinyin[vowel:]
+        result.append(unicodedata.normalize('NFC', pinyin))
+    return ' '.join(result)
+
 
 tonemarks = ["", u("̄"), u("́"), u("̌"), u("̀"), ""]

--- a/test_cedict.py
+++ b/test_cedict.py
@@ -7,6 +7,13 @@ import pinyin.cedict
 
 class BasicTestSuite(unittest.TestCase):
     """Basic test cases."""
+
+    def test_pronounce_word(self):
+        self.assertEqual(
+            pinyin.cedict.pronounce_word("还是"),
+            "hai2 shi5"
+        )
+
     def test_translate_word(self):
         self.assertEqual(
             list(pinyin.cedict.translate_word("你好")),
@@ -41,6 +48,19 @@ class BasicTestSuite(unittest.TestCase):
                  'shrewd', 'alert', 'perverse', 'contrary to reason',
                  'irregular', 'abnormal']]]
         )
+        self.assertEqual(
+            list(pinyin.cedict.all_phrase_translations(
+                "刻是梦还是真", include_pinyin=True)),
+            [['刻', 'kè', ['quarter (hour)', 'moment', 'to carve', 'to engrave', 'to cut',
+                          'oppressive', 'classifier for short time intervals']],
+             ['是', 'shì', ['variant of 是[shi4]', '(used in given names)']],
+             ['梦', 'mèng', ['dream', 'CL:場|场[chang2],個|个[ge4]']],
+             ['还', 'huán', ['to pay back', 'to return']],
+             ['还是', 'hái shi', ['or', 'still', 'nevertheless', 'had better']],
+             ['是', 'shì', ['variant of 是[shi4]', '(used in given names)']],
+             ['真', 'zhēn', ['really', 'truly', 'indeed', 'real', 'true', 'genuine']]]
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION

## What does this do?
- Adds an `include_pinyin` option to the translation function, with pinyin returned in either format (numerical or diacritical)
```
['还', 'huán', ['to pay back', 'to return']]
['还是', 'hái shi', ['or', 'still', 'nevertheless', 'had better']]
['是', 'shì', ['variant of 是[shi4]', '(used in given names)']]
```

- Minor: Adds a pronunciation dictionary, so you can `pronounce_word` in addition to translating it
```
>>> pronounce_word("还是")
"hai2 shi5"
```

## Testing
- Added a test for this behavior!

## Why?
Got really disappointed when `pinyin.get("还是")` returned "huánshì"

It still does that... Although, with this updated `all_phrase_translations` function, you can pick out the right pronunciation..
