### PR TITLE
fix: qíu -> qiú

### DIFF
--- a/pinyin/pinyin.py
+++ b/pinyin/pinyin.py
@@ -37,7 +37,8 @@ def _pinyin_generator(chars, format):
         elif format == "diacritical":
             # Find first vowel -- where we should put the diacritical mark
             vowels = itertools.chain((c for c in pinyin if c in "aeo"),
-                                     (c for c in pinyin if c in "iuv"))
+                                     (c for c in pinyin if c in "uv"),
+                                     (c for c in pinyin if c in "i"))
             vowel = pinyin.index(next(vowels)) + 1
             pinyin = pinyin[:vowel] + tonemarks[tone] + pinyin[vowel:]
         else:


### PR DESCRIPTION
for word 求，current result is qíu. from `https://baike.baidu.com/item/%E6%B1%82/6435747`, the correct mark is qiú.